### PR TITLE
updated get method to public

### DIFF
--- a/src/HttpClient/Response.php
+++ b/src/HttpClient/Response.php
@@ -107,7 +107,7 @@ class Response implements ResponseInterface
      * @param  mixed  $default
      * @return mixed
      */
-    protected function get($target, $key, $default = null)
+    public function get($target, $key, $default = null)
     {
         $key = explode('.', $key);
 


### PR DESCRIPTION
Fixes
```Access type for interface method Cloudflare\Contracts\ResponseInterface::get() must be public``` error
