### PR TITLE
updated get method to public no 2

### DIFF
--- a/src/Contracts/ResponseInterface.php
+++ b/src/Contracts/ResponseInterface.php
@@ -58,5 +58,5 @@ interface ResponseInterface extends Stringable
      * @param  mixed  $default
      * @return mixed
      */
-    protected function get($target, $key, $default = null);
+    public function get($target, $key, $default = null);
 }


### PR DESCRIPTION
Fixes
```Access type for interface method Cloudflare\Contracts\ResponseInterface::get() must be public``` error 2
