### PR TITLE
Update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 * text=auto
 
-/doc export-ignore
+/docs export-ignore
+/local-test export-ignore
 /test export-ignore
 /.* export-ignore
+/pint.json export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
This PR updates the .gitattributes, to prevent development files from being included in the vendor directory by composer.