### PR TITLE
Updates GitHub Release action to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
Updates the `softprops/action-gh-release` GitHub Action from version 2 to version 3. This ensures the release workflow leverages the latest version of the action, incorporating any stability improvements, bug fixes, or new features.