### PR TITLE
Allow optional 'rules' parameter for ruleset creation

### DIFF
--- a/src/Endpoints/Accounts/Rulesets.php
+++ b/src/Endpoints/Accounts/Rulesets.php
@@ -35,7 +35,7 @@ class Rulesets extends AbstractEndpoint
     public function create(string $accountId, array|Ruleset $values): ResponseInterface
     {
         if (is_array($values)) {
-            $this->requiredParams(['name', 'kind', 'phase', 'rules'], $values);
+            $this->requiredParams(['name', 'kind', 'phase'], $values);
         } else {
             $values = $values->toArray();
         }

--- a/src/Endpoints/Zones/Rulesets.php
+++ b/src/Endpoints/Zones/Rulesets.php
@@ -35,7 +35,7 @@ class Rulesets extends AbstractEndpoint
     public function create(string $zoneId, array|Ruleset $values): ResponseInterface
     {
         if (is_array($values)) {
-            $this->requiredParams(['name', 'kind', 'phase', 'rules'], $values);
+            $this->requiredParams(['name', 'kind', 'phase'], $values);
         } else {
             $values = $values->toArray();
         }

--- a/test/Tests/Endpoints/Accounts/RulesetsTest.php
+++ b/test/Tests/Endpoints/Accounts/RulesetsTest.php
@@ -47,6 +47,41 @@ class RulesetsTest extends TestCase
     }
 
     #[Test]
+    public function shouldCreateWithEmptyRulesArray()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode(['success' => true, 'result' => ['id' => 'ruleset_id']])),
+        ]);
+
+        $response = $client->accounts()->rulesets()->create('account_id', [
+            'name' => 'my ruleset',
+            'kind' => 'root',
+            'phase' => 'http_request_firewall_custom',
+            'rules' => [],
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+    }
+
+    #[Test]
+    public function shouldCreateWithoutRulesKey()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode(['success' => true, 'result' => ['id' => 'ruleset_id']])),
+        ]);
+
+        $response = $client->accounts()->rulesets()->create('account_id', [
+            'name' => 'my ruleset',
+            'kind' => 'root',
+            'phase' => 'http_request_firewall_custom',
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+    }
+
+    #[Test]
     public function shouldCreateWithRulesetObject()
     {
         $client = $this->mockClient([

--- a/test/Tests/Endpoints/Zones/RulesetsTest.php
+++ b/test/Tests/Endpoints/Zones/RulesetsTest.php
@@ -47,6 +47,41 @@ class RulesetsTest extends TestCase
     }
 
     #[Test]
+    public function shouldCreateWithEmptyRulesArray()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode(['success' => true, 'result' => ['id' => 'ruleset_id']])),
+        ]);
+
+        $response = $client->zones()->rulesets()->create('zone_id', [
+            'name' => 'my ruleset',
+            'kind' => 'zone',
+            'phase' => 'http_request_firewall_custom',
+            'rules' => [],
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+    }
+
+    #[Test]
+    public function shouldCreateWithoutRulesKey()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode(['success' => true, 'result' => ['id' => 'ruleset_id']])),
+        ]);
+
+        $response = $client->zones()->rulesets()->create('zone_id', [
+            'name' => 'my ruleset',
+            'kind' => 'zone',
+            'phase' => 'http_request_firewall_custom',
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+    }
+
+    #[Test]
     public function shouldCreateWithRulesetObject()
     {
         $client = $this->mockClient([


### PR DESCRIPTION
The Cloudflare API permits creating rulesets without providing the 'rules' array, or with an empty one. Previously, the client library incorrectly marked 'rules' as a required field, preventing successful creation in these valid scenarios. This change corrects the client's validation and adds tests to confirm the new behavior.
