### PR TITLE
Expands Load Balancer API functionality

### DIFF
--- a/docs/content/2.api/0.accounts/19.load-balancer-monitor-groups.md
+++ b/docs/content/2.api/0.accounts/19.load-balancer-monitor-groups.md
@@ -1,0 +1,94 @@
+---
+title: Load Balancer Monitor Groups
+description: Manage groups of monitors that can be applied together to load balancer pools.
+navigation:
+    title: Load Balancer Monitor Groups
+---
+
+# Load Balancer Monitor Groups
+
+Manage groups of monitors that can be applied together to load balancer pools.
+
+:button-link[Cloudflare API docs]{icon="heroicons-outline:external-link" href="https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-list-monitor-groups" blank}
+
+## List
+
+List configured load balancer monitor groups for an account.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitorGroups()->list('account_id');
+```
+
+## Create
+
+Create a new load balancer monitor group for an account.
+
+```php [php]
+$values = [
+    'description' => 'Primary datacenter monitors',
+    'members' => [
+        [
+            'monitor_id' => 'monitor_id',
+            'enabled' => true,
+            'monitoring_only' => false,
+            'must_be_healthy' => true,
+        ],
+    ],
+];
+
+$response = $client->accounts()->loadBalancerMonitorGroups()->create('account_id', $values);
+```
+
+## Details
+
+Get a single configured load balancer monitor group for an account.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitorGroups()->details('account_id', 'monitor_group_id');
+```
+
+## Patch
+
+Apply changes to an existing monitor group, overwriting only the supplied properties.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitorGroups()->patch('account_id', 'monitor_group_id', [
+    'description' => 'Secondary datacenter monitors',
+]);
+```
+
+## Update
+
+Update an existing load balancer monitor group for an account.
+
+```php [php]
+$values = [
+    'description' => 'Primary datacenter monitors',
+    'members' => [
+        [
+            'monitor_id' => 'monitor_id',
+            'enabled' => true,
+            'monitoring_only' => false,
+            'must_be_healthy' => true,
+        ],
+    ],
+];
+
+$response = $client->accounts()->loadBalancerMonitorGroups()->update('account_id', 'monitor_group_id', $values);
+```
+
+## Delete
+
+Delete a load balancer monitor group for an account.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitorGroups()->delete('account_id', 'monitor_group_id');
+```
+
+## References
+
+List the pools that reference a given monitor group.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitorGroups()->references('account_id', 'monitor_group_id');
+```

--- a/docs/content/2.api/0.accounts/6.load-balancers.md
+++ b/docs/content/2.api/0.accounts/6.load-balancers.md
@@ -62,3 +62,39 @@ Delete a load balancer for an account.
 ```php [php]
 $response = $client->accounts()->loadBalancers()->delete('account_id', 'load_balancer_id');
 ```
+
+## Patch
+
+Apply changes to an existing load balancer, overwriting only the supplied properties.
+
+```php [php]
+$response = $client->accounts()->loadBalancers()->patch('account_id', 'load_balancer_id', [
+    'enabled' => false,
+]);
+```
+
+## Usage
+
+Fetch the current load balancer usage for an account.
+
+```php [php]
+$response = $client->accounts()->loadBalancers()->usage('account_id');
+```
+
+## Search
+
+Search load balancing resources (Load Balancers, Pools, Monitors) by name.
+
+```php [php]
+$response = $client->accounts()->loadBalancers()->search('account_id', [
+    'query' => 'www.example.com',
+]);
+```
+
+## Preview Result
+
+Get the result of a previously requested monitor or pool preview.
+
+```php [php]
+$response = $client->accounts()->loadBalancers()->previewResult('account_id', 'preview_id');
+```

--- a/docs/content/2.api/0.accounts/7.load-balancer-monitors.md
+++ b/docs/content/2.api/0.accounts/7.load-balancer-monitors.md
@@ -73,3 +73,21 @@ $values = [
 
 $response = $client->accounts()->loadBalancerMonitors()->preview('account_id', 'monitor_id', $values);
 ```
+
+## Patch
+
+Apply changes to an existing monitor, overwriting only the supplied properties.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitors()->patch('account_id', 'monitor_id', [
+    'method' => 'POST',
+]);
+```
+
+## References
+
+List the load balancers and pools that reference a given monitor.
+
+```php [php]
+$response = $client->accounts()->loadBalancerMonitors()->references('account_id', 'monitor_id');
+```

--- a/docs/content/2.api/0.accounts/8.load-balancer-pools.md
+++ b/docs/content/2.api/0.accounts/8.load-balancer-pools.md
@@ -91,3 +91,31 @@ $values = [
 
 $response = $client->accounts()->loadBalancerPools()->preview('account_id', 'pool_id', $values);
 ```
+
+## Patch
+
+Apply changes to an existing pool, overwriting only the supplied properties.
+
+```php [php]
+$response = $client->accounts()->loadBalancerPools()->patch('account_id', 'pool_id', [
+    'enabled' => false,
+]);
+```
+
+## Patch Multiple Pools
+
+Apply changes to a number of existing pools, overwriting the supplied properties. Returns the list of affected pools.
+
+```php [php]
+$response = $client->accounts()->loadBalancerPools()->patchMultiplePools('account_id', [
+    ['id' => 'pool_id', 'enabled' => false],
+]);
+```
+
+## References
+
+List the load balancers that reference a given pool.
+
+```php [php]
+$response = $client->accounts()->loadBalancerPools()->references('account_id', 'pool_id');
+```

--- a/docs/content/2.api/0.accounts/9.load-balancer-regions.md
+++ b/docs/content/2.api/0.accounts/9.load-balancer-regions.md
@@ -18,3 +18,11 @@ List Load Balancer region mappings for an account.
 ```php [php]
 $response = $client->accounts()->loadBalancerRegions()->list('account_id');
 ```
+
+## Details
+
+Get a single Load Balancer region mapping for an account.
+
+```php [php]
+$response = $client->accounts()->loadBalancerRegions()->details('account_id', 'WNAM');
+```

--- a/docs/content/2.api/1.zones/15.load-balancers.md
+++ b/docs/content/2.api/1.zones/15.load-balancers.md
@@ -62,3 +62,13 @@ Delete a load balancer for a zone.
 ```php [php]
 $response = $client->zones()->loadBalancers()->delete('zone_id', 'load_balancer_id');
 ```
+
+## Patch
+
+Apply changes to an existing load balancer, overwriting only the supplied properties.
+
+```php [php]
+$response = $client->zones()->loadBalancers()->patch('zone_id', 'load_balancer_id', [
+    'enabled' => false,
+]);
+```

--- a/docs/content/4.coverage.md
+++ b/docs/content/4.coverage.md
@@ -141,48 +141,48 @@ Please find below implemented endpoints.
   - [ ] Billing Profile Details
 
 ## Account Load Balancer Monitor Groups
-  - [ ] List Monitor Groups
-  - [ ] Create Monitor Group
-  - [ ] Delete Monitor Group
-  - [ ] Monitor Group Details
-  - [ ] Patch Monitor Group
-  - [ ] Update Monitor Group
-  - [ ] List Monitor Group References
+  - [x] [List Monitor Groups](/api/accounts/load-balancer-monitor-groups#list)
+  - [x] [Create Monitor Group](/api/accounts/load-balancer-monitor-groups#create)
+  - [x] [Delete Monitor Group](/api/accounts/load-balancer-monitor-groups#delete)
+  - [x] [Monitor Group Details](/api/accounts/load-balancer-monitor-groups#details)
+  - [x] [Patch Monitor Group](/api/accounts/load-balancer-monitor-groups#patch)
+  - [x] [Update Monitor Group](/api/accounts/load-balancer-monitor-groups#update)
+  - [x] [List Monitor Group References](/api/accounts/load-balancer-monitor-groups#references)
 
 ## Account Load Balancer Monitors
   - [x] [List Monitors](/api/accounts/load-balancer-monitors#list)
   - [x] [Create Monitor](/api/accounts/load-balancer-monitors#create)
   - [x] [Delete Monitor](/api/accounts/load-balancer-monitors#delete)
   - [x] [Monitor Details](/api/accounts/load-balancer-monitors#details)
-  - [ ] Patch Monitor
+  - [x] [Patch Monitor](/api/accounts/load-balancer-monitors#patch)
   - [x] [Update Monitor](/api/accounts/load-balancer-monitors#update)
   - [x] [Preview Monitor](/api/accounts/load-balancer-monitors#preview)
-  - [ ] List Monitor References
-  - [ ] Preview Result
+  - [x] [List Monitor References](/api/accounts/load-balancer-monitors#references)
+  - [x] [Preview Result](/api/accounts/load-balancers#preview-result)
 
 ## Account Load Balancer Pools
   - [x] [List Pools](/api/accounts/load-balancer-pools#list)
-  - [ ] Patch Pools
+  - [x] [Patch Pools](/api/accounts/load-balancer-pools#patch-multiple-pools)
   - [x] [Create Pool](/api/accounts/load-balancer-pools#create)
   - [x] [Delete Pool](/api/accounts/load-balancer-pools#delete)
   - [x] [Pool Details](/api/accounts/load-balancer-pools#details)
-  - [ ] Patch Pool
+  - [x] [Patch Pool](/api/accounts/load-balancer-pools#patch)
   - [x] [Update Pool](/api/accounts/load-balancer-pools#update)
   - [x] [Pool Health Details](/api/accounts/load-balancer-pools#health)
   - [x] [Preview Pool](/api/accounts/load-balancer-pools#preview)
-  - [ ] List Pool References
+  - [x] [List Pool References](/api/accounts/load-balancer-pools#references)
 
 ## Account Load Balancer Search
-  - [ ] Search Resources
+  - [x] [Search Resources](/api/accounts/load-balancers#search)
 
 ## Account Load Balancers
-  - [ ] List Account Load Balancers
-  - [ ] Create Account Load Balancer
-  - [ ] List Load Balancer Usage
-  - [ ] Delete Account Load Balancer
-  - [ ] Account Load Balancer Details
-  - [ ] Patch Account Load Balancer
-  - [ ] Update Account Load Balancer
+  - [x] [List Account Load Balancers](/api/accounts/load-balancers#list)
+  - [x] [Create Account Load Balancer](/api/accounts/load-balancers#create)
+  - [x] [List Load Balancer Usage](/api/accounts/load-balancers#usage)
+  - [x] [Delete Account Load Balancer](/api/accounts/load-balancers#delete)
+  - [x] [Account Load Balancer Details](/api/accounts/load-balancers#details)
+  - [x] [Patch Account Load Balancer](/api/accounts/load-balancers#patch)
+  - [x] [Update Account Load Balancer](/api/accounts/load-balancers#update)
 
 ## Account Members
   - [x] [List Members](/api/accounts/members#list)
@@ -1812,34 +1812,34 @@ Please find below implemented endpoints.
   - [x] [Create Monitor](/api/accounts/load-balancer-monitors#create)
   - [x] [Delete Monitor](/api/accounts/load-balancer-monitors#delete)
   - [x] [Monitor Details](/api/accounts/load-balancer-monitors#details)
-  - [ ] Patch Monitor
+  - [x] [Patch Monitor](/api/accounts/load-balancer-monitors#patch)
   - [x] [Update Monitor](/api/accounts/load-balancer-monitors#update)
   - [x] [Preview Monitor](/api/accounts/load-balancer-monitors#preview)
-  - [ ] List Monitor References
-  - [ ] Preview Result
+  - [x] [List Monitor References](/api/accounts/load-balancer-monitors#references)
+  - [x] [Preview Result](/api/accounts/load-balancers#preview-result)
 
 ## Load Balancer Pools
   - [x] [List Pools](/api/accounts/load-balancer-pools#list)
-  - [ ] Patch Pools
+  - [x] [Patch Pools](/api/accounts/load-balancer-pools#patch-multiple-pools)
   - [x] [Create Pool](/api/accounts/load-balancer-pools#create)
   - [x] [Delete Pool](/api/accounts/load-balancer-pools#delete)
   - [x] [Pool Details](/api/accounts/load-balancer-pools#details)
-  - [ ] Patch Pool
+  - [x] [Patch Pool](/api/accounts/load-balancer-pools#patch)
   - [x] [Update Pool](/api/accounts/load-balancer-pools#update)
   - [x] [Pool Health Details](/api/accounts/load-balancer-pools#health)
   - [x] [Preview Pool](/api/accounts/load-balancer-pools#preview)
-  - [ ] List Pool References
+  - [x] [List Pool References](/api/accounts/load-balancer-pools#references)
 
 ## Load Balancer Regions
   - [x] [List Regions](/api/accounts/load-balancer-regions#list)
-  - [ ] Get Region
+  - [x] [Get Region](/api/accounts/load-balancer-regions#details)
 
 ## Load Balancers
   - [x] [List Load Balancers](/api/zones/load-balancers#list)
   - [x] [Create Load Balancer](/api/zones/load-balancers#create)
   - [x] [Delete Load Balancer](/api/zones/load-balancers#delete)
   - [x] [Load Balancer Details](/api/zones/load-balancers#details)
-  - [ ] Patch Load Balancer
+  - [x] [Patch Load Balancer](/api/zones/load-balancers#patch)
   - [x] [Update Load Balancer](/api/zones/load-balancers#update)
 
 ## Log Explorer Datasets

--- a/src/Endpoints/Accounts.php
+++ b/src/Endpoints/Accounts.php
@@ -11,6 +11,7 @@ use Cloudflare\Endpoints\Accounts\LoadBalancers;
 use Cloudflare\Endpoints\Accounts\LoadBalancerMonitors;
 use Cloudflare\Endpoints\Accounts\LoadBalancerPools;
 use Cloudflare\Endpoints\Accounts\LoadBalancerRegions;
+use Cloudflare\Endpoints\Accounts\LoadBalancerMonitorGroups;
 use Cloudflare\Endpoints\Accounts\R2Buckets;
 use Cloudflare\Endpoints\Accounts\R2Cors;
 use Cloudflare\Endpoints\Accounts\R2Lifecycle;
@@ -198,6 +199,16 @@ class Accounts extends AbstractEndpoint
     public function loadBalancerRegions(): LoadBalancerRegions
     {
         return new LoadBalancerRegions($this->getClient());
+    }
+
+    /**
+     * Account Load Balancer Monitor Groups
+     *
+     * @return \Cloudflare\Endpoints\Accounts\LoadBalancerMonitorGroups
+     */
+    public function loadBalancerMonitorGroups(): LoadBalancerMonitorGroups
+    {
+        return new LoadBalancerMonitorGroups($this->getClient());
     }
 
     /**

--- a/src/Endpoints/Accounts/LoadBalancerMonitorGroups.php
+++ b/src/Endpoints/Accounts/LoadBalancerMonitorGroups.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Cloudflare\Endpoints\Accounts;
+
+use Cloudflare\Endpoints\AbstractEndpoint;
+use Cloudflare\Contracts\ResponseInterface;
+
+class LoadBalancerMonitorGroups extends AbstractEndpoint
+{
+    /**
+     * List configured load balancer monitor groups for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-list-monitor-groups
+     *
+     * @param string $accountId Account Identifier.
+     *
+     * @return ResponseInterface List monitor groups response
+     */
+    public function list(string $accountId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/monitor_groups");
+    }
+
+    /**
+     * Create a new load balancer monitor group for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-create-monitor-group
+     *
+     * @param string $accountId Account Identifier.
+     * @param array $values Values to set on the monitor group, e.g. `description`, `members`.
+     *
+     * @return ResponseInterface Create a monitor group response
+     */
+    public function create(string $accountId, array $values): ResponseInterface
+    {
+        $this->requiredParams(['description', 'members'], $values);
+
+        return $this->getHttpClient()->post("/accounts/{$accountId}/load_balancers/monitor_groups", $values);
+    }
+
+    /**
+     * Get a single configured load balancer monitor group for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-monitor-group-details
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorGroupId Monitor Group Identifier.
+     *
+     * @return ResponseInterface Monitor group details response
+     */
+    public function details(string $accountId, string $monitorGroupId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/monitor_groups/{$monitorGroupId}");
+    }
+
+    /**
+     * Apply changes to an existing monitor group, overwriting only the supplied properties.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-patch-monitor-group
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorGroupId Monitor Group Identifier.
+     * @param array $values Values to patch on the monitor group.
+     *
+     * @return ResponseInterface Patch a monitor group response
+     */
+    public function patch(string $accountId, string $monitorGroupId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/accounts/{$accountId}/load_balancers/monitor_groups/{$monitorGroupId}", $values);
+    }
+
+    /**
+     * Update an existing load balancer monitor group for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-update-monitor-group
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorGroupId Monitor Group Identifier.
+     * @param array $values Values to set on the monitor group, e.g. `description`, `members`.
+     *
+     * @return ResponseInterface Update a monitor group response
+     */
+    public function update(string $accountId, string $monitorGroupId, array $values): ResponseInterface
+    {
+        $this->requiredParams(['description', 'members'], $values);
+
+        return $this->getHttpClient()->put("/accounts/{$accountId}/load_balancers/monitor_groups/{$monitorGroupId}", $values);
+    }
+
+    /**
+     * Delete a load balancer monitor group for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-delete-monitor-group
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorGroupId Monitor Group Identifier.
+     *
+     * @return ResponseInterface Delete a monitor group response
+     */
+    public function delete(string $accountId, string $monitorGroupId): ResponseInterface
+    {
+        return $this->getHttpClient()->delete("/accounts/{$accountId}/load_balancers/monitor_groups/{$monitorGroupId}");
+    }
+
+    /**
+     * List the pools that reference a given monitor group.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitor-groups-list-monitor-group-references
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorGroupId Monitor Group Identifier.
+     *
+     * @return ResponseInterface List monitor group references response
+     */
+    public function references(string $accountId, string $monitorGroupId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/monitor_groups/{$monitorGroupId}/references");
+    }
+}

--- a/src/Endpoints/Accounts/LoadBalancerMonitors.php
+++ b/src/Endpoints/Accounts/LoadBalancerMonitors.php
@@ -97,4 +97,35 @@ class LoadBalancerMonitors extends AbstractEndpoint
     {
         return $this->getHttpClient()->post("/accounts/{$accountId}/load_balancers/monitors/{$monitorId}/preview", $values);
     }
+
+    /**
+     * Apply changes to an existing monitor, overwriting only the supplied properties.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitors-patch-monitor
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorId Monitor Identifier.
+     * @param array $values Values to patch on the monitor.
+     *
+     * @return ResponseInterface Patch a monitor response
+     */
+    public function patch(string $accountId, string $monitorId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/accounts/{$accountId}/load_balancers/monitors/{$monitorId}", $values);
+    }
+
+    /**
+     * List the load balancers and pools that reference a given monitor.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitors-list-monitor-references
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $monitorId Monitor Identifier.
+     *
+     * @return ResponseInterface List monitor references response
+     */
+    public function references(string $accountId, string $monitorId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/monitors/{$monitorId}/references");
+    }
 }

--- a/src/Endpoints/Accounts/LoadBalancerPools.php
+++ b/src/Endpoints/Accounts/LoadBalancerPools.php
@@ -116,4 +116,50 @@ class LoadBalancerPools extends AbstractEndpoint
     {
         return $this->getHttpClient()->post("/accounts/{$accountId}/load_balancers/pools/{$poolId}/preview", $values);
     }
+
+    /**
+     * Apply changes to an existing pool, overwriting only the supplied properties.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-pools-patch-pool
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $poolId Pool Identifier.
+     * @param array $values Values to patch on the pool.
+     *
+     * @return ResponseInterface Patch a pool response
+     */
+    public function patch(string $accountId, string $poolId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/accounts/{$accountId}/load_balancers/pools/{$poolId}", $values);
+    }
+
+    /**
+     * Apply changes to a number of existing pools, overwriting the supplied properties. Returns the list of affected pools.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-pools-patch-pools
+     *
+     * @param string $accountId Account Identifier.
+     * @param array $values List of pool patches to apply, each identified by `id`.
+     *
+     * @return ResponseInterface Patch pools response
+     */
+    public function patchMultiplePools(string $accountId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/accounts/{$accountId}/load_balancers/pools", $values);
+    }
+
+    /**
+     * List the load balancers that reference a given pool.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-pools-list-pool-references
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $poolId Pool Identifier.
+     *
+     * @return ResponseInterface List pool references response
+     */
+    public function references(string $accountId, string $poolId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/pools/{$poolId}/references");
+    }
 }

--- a/src/Endpoints/Accounts/LoadBalancerRegions.php
+++ b/src/Endpoints/Accounts/LoadBalancerRegions.php
@@ -20,4 +20,19 @@ class LoadBalancerRegions extends AbstractEndpoint
     {
         return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/regions");
     }
+
+    /**
+     * Get a single Load Balancer region mapping for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/load-balancer-regions-get-region
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $regionId Region Identifier.
+     *
+     * @return ResponseInterface Get region response
+     */
+    public function details(string $accountId, string $regionId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/regions/{$regionId}");
+    }
 }

--- a/src/Endpoints/Accounts/LoadBalancers.php
+++ b/src/Endpoints/Accounts/LoadBalancers.php
@@ -85,4 +85,64 @@ class LoadBalancers extends AbstractEndpoint
     {
         return $this->getHttpClient()->delete("/accounts/{$accountId}/load_balancers/{$loadBalancerId}");
     }
+
+    /**
+     * Apply changes to an existing load balancer, overwriting only the supplied properties.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancers-patch-account-load-balancer
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $loadBalancerId Load Balancer Identifier.
+     * @param array $values Values to patch on the load balancer.
+     *
+     * @return ResponseInterface Patch a load balancer response
+     */
+    public function patch(string $accountId, string $loadBalancerId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/accounts/{$accountId}/load_balancers/{$loadBalancerId}", $values);
+    }
+
+    /**
+     * Fetches the current load balancer usage for an account.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancers-list-load-balancer-usage
+     *
+     * @param string $accountId Account Identifier.
+     *
+     * @return ResponseInterface List load balancer usage response
+     */
+    public function usage(string $accountId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/usage");
+    }
+
+    /**
+     * Search load balancing resources (Load Balancers, Pools, Monitors) by name.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-search-search-resources
+     *
+     * @param string $accountId Account Identifier.
+     * @param array $params Query Parameters, e.g. `query`, `references`, `page`, `per_page`.
+     *
+     * @return ResponseInterface Search resources response
+     */
+    public function search(string $accountId, array $params = []): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/search", $params);
+    }
+
+    /**
+     * Get the result of a previously requested monitor or pool preview.
+     *
+     * @link https://developers.cloudflare.com/api/operations/account-load-balancer-monitors-preview-result
+     *
+     * @param string $accountId Account Identifier.
+     * @param string $previewId Preview Identifier.
+     *
+     * @return ResponseInterface Preview result response
+     */
+    public function previewResult(string $accountId, string $previewId): ResponseInterface
+    {
+        return $this->getHttpClient()->get("/accounts/{$accountId}/load_balancers/preview/{$previewId}");
+    }
 }

--- a/src/Endpoints/Zones/LoadBalancers.php
+++ b/src/Endpoints/Zones/LoadBalancers.php
@@ -85,4 +85,20 @@ class LoadBalancers extends AbstractEndpoint
     {
         return $this->getHttpClient()->delete("/zones/{$zoneId}/load_balancers/{$loadBalancerId}");
     }
+
+    /**
+     * Apply changes to an existing load balancer, overwriting only the supplied properties.
+     *
+     * @link https://developers.cloudflare.com/api/operations/load-balancers-patch-load-balancer
+     *
+     * @param string $zoneId Zone Identifier.
+     * @param string $loadBalancerId Load Balancer Identifier.
+     * @param array $values Values to patch on the load balancer.
+     *
+     * @return ResponseInterface Patch a load balancer response
+     */
+    public function patch(string $zoneId, string $loadBalancerId, array $values): ResponseInterface
+    {
+        return $this->getHttpClient()->patch("/zones/{$zoneId}/load_balancers/{$loadBalancerId}", $values);
+    }
 }

--- a/test/Tests/Endpoints/Accounts/LoadBalancerMonitorGroupsTest.php
+++ b/test/Tests/Endpoints/Accounts/LoadBalancerMonitorGroupsTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Cloudflare\Tests\Endpoints\Accounts;
+
+use Cloudflare\Tests\Concerns\InteractsWithMockClient;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class LoadBalancerMonitorGroupsTest extends TestCase
+{
+    use InteractsWithMockClient;
+
+    #[Test]
+    public function shouldListMonitorGroups()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['id' => 'monitor_group_id'],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->list('account_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('monitor_group_id', $response->json('result.0.id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldCreateMonitorGroup()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_group_id',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->create('account_id', [
+            'description' => 'Primary datacenter monitors',
+            'members' => [
+                ['monitor_id' => 'monitor_id', 'enabled' => true, 'monitoring_only' => false, 'must_be_healthy' => true],
+            ],
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('monitor_group_id', $response->json('result.id'));
+
+        $this->assertSame('POST', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldGetMonitorGroupDetails()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_group_id',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->details('account_id', 'monitor_group_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('monitor_group_id', $response->json('result.id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups/monitor_group_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldPatchMonitorGroup()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_group_id',
+                    'description' => 'Secondary datacenter monitors',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->patch('account_id', 'monitor_group_id', [
+            'description' => 'Secondary datacenter monitors',
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('Secondary datacenter monitors', $response->json('result.description'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups/monitor_group_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldUpdateMonitorGroup()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_group_id',
+                    'description' => 'Primary datacenter monitors',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->update('account_id', 'monitor_group_id', [
+            'description' => 'Primary datacenter monitors',
+            'members' => [
+                ['monitor_id' => 'monitor_id', 'enabled' => true, 'monitoring_only' => false, 'must_be_healthy' => true],
+            ],
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('Primary datacenter monitors', $response->json('result.description'));
+
+        $this->assertSame('PUT', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups/monitor_group_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldDeleteMonitorGroup()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_group_id',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->delete('account_id', 'monitor_group_id');
+
+        $this->assertTrue($response->successful());
+
+        $this->assertSame('DELETE', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups/monitor_group_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldListMonitorGroupReferences()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['reference_type' => 'referral', 'resource_id' => 'pool_id'],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitorGroups()->references('account_id', 'monitor_group_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('pool_id', $response->json('result.0.resource_id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitor_groups/monitor_group_id/references', $this->lastRequest()->getUri()->getPath());
+    }
+}

--- a/test/Tests/Endpoints/Accounts/LoadBalancerMonitorsTest.php
+++ b/test/Tests/Endpoints/Accounts/LoadBalancerMonitorsTest.php
@@ -145,4 +145,49 @@ class LoadBalancerMonitorsTest extends TestCase
         $this->assertSame('POST', $this->lastRequest()->getMethod());
         $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitors/monitor_id/preview', $this->lastRequest()->getUri()->getPath());
     }
+
+    #[Test]
+    public function shouldPatchMonitor()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'monitor_id',
+                    'method' => 'POST',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitors()->patch('account_id', 'monitor_id', [
+            'method' => 'POST',
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('POST', $response->json('result.method'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitors/monitor_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldListMonitorReferences()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['reference_type' => 'referral', 'resource_id' => 'load_balancer_id'],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerMonitors()->references('account_id', 'monitor_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('load_balancer_id', $response->json('result.0.resource_id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/monitors/monitor_id/references', $this->lastRequest()->getUri()->getPath());
+    }
 }

--- a/test/Tests/Endpoints/Accounts/LoadBalancerPoolsTest.php
+++ b/test/Tests/Endpoints/Accounts/LoadBalancerPoolsTest.php
@@ -171,4 +171,72 @@ class LoadBalancerPoolsTest extends TestCase
         $this->assertSame('POST', $this->lastRequest()->getMethod());
         $this->assertSame('/client/v4/accounts/account_id/load_balancers/pools/pool_id/preview', $this->lastRequest()->getUri()->getPath());
     }
+
+    #[Test]
+    public function shouldPatchPool()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'pool_id',
+                    'enabled' => false,
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerPools()->patch('account_id', 'pool_id', [
+            'enabled' => false,
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertFalse($response->json('result.enabled'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/pools/pool_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldPatchMultiplePools()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['id' => 'pool_id', 'enabled' => false],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerPools()->patchMultiplePools('account_id', [
+            ['id' => 'pool_id', 'enabled' => false],
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertFalse($response->json('result.0.enabled'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/pools', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldListPoolReferences()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['reference_type' => 'referral', 'resource_id' => 'load_balancer_id'],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerPools()->references('account_id', 'pool_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('load_balancer_id', $response->json('result.0.resource_id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/pools/pool_id/references', $this->lastRequest()->getUri()->getPath());
+    }
 }

--- a/test/Tests/Endpoints/Accounts/LoadBalancerRegionsTest.php
+++ b/test/Tests/Endpoints/Accounts/LoadBalancerRegionsTest.php
@@ -31,4 +31,25 @@ class LoadBalancerRegionsTest extends TestCase
         $this->assertSame('GET', $this->lastRequest()->getMethod());
         $this->assertSame('/client/v4/accounts/account_id/load_balancers/regions', $this->lastRequest()->getUri()->getPath());
     }
+
+    #[Test]
+    public function shouldGetRegionDetails()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'region_code' => 'WNAM',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancerRegions()->details('account_id', 'WNAM');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('WNAM', $response->json('result.region_code'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/regions/WNAM', $this->lastRequest()->getUri()->getPath());
+    }
 }

--- a/test/Tests/Endpoints/Accounts/LoadBalancersTest.php
+++ b/test/Tests/Endpoints/Accounts/LoadBalancersTest.php
@@ -124,4 +124,93 @@ class LoadBalancersTest extends TestCase
         $this->assertSame('DELETE', $this->lastRequest()->getMethod());
         $this->assertSame('/client/v4/accounts/account_id/load_balancers/load_balancer_id', $this->lastRequest()->getUri()->getPath());
     }
+
+    #[Test]
+    public function shouldPatchLoadBalancer()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'load_balancer_id',
+                    'enabled' => false,
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancers()->patch('account_id', 'load_balancer_id', [
+            'enabled' => false,
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertFalse($response->json('result.enabled'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/load_balancer_id', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldGetLoadBalancerUsage()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'load_balancers' => 1,
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancers()->usage('account_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame(1, $response->json('result.load_balancers'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/usage', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldSearchLoadBalancerResources()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    ['id' => 'load_balancer_id'],
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancers()->search('account_id', [
+            'query' => 'www.example.com',
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('load_balancer_id', $response->json('result.0.id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/search', $this->lastRequest()->getUri()->getPath());
+    }
+
+    #[Test]
+    public function shouldGetPreviewResult()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'preview_id' => 'preview_id',
+                ],
+            ])),
+        ]);
+
+        $response = $client->accounts()->loadBalancers()->previewResult('account_id', 'preview_id');
+
+        $this->assertTrue($response->successful());
+        $this->assertSame('preview_id', $response->json('result.preview_id'));
+
+        $this->assertSame('GET', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/accounts/account_id/load_balancers/preview/preview_id', $this->lastRequest()->getUri()->getPath());
+    }
 }

--- a/test/Tests/Endpoints/Zones/LoadBalancersTest.php
+++ b/test/Tests/Endpoints/Zones/LoadBalancersTest.php
@@ -124,4 +124,28 @@ class LoadBalancersTest extends TestCase
         $this->assertSame('DELETE', $this->lastRequest()->getMethod());
         $this->assertSame('/client/v4/zones/zone_id/load_balancers/load_balancer_id', $this->lastRequest()->getUri()->getPath());
     }
+
+    #[Test]
+    public function shouldPatchLoadBalancer()
+    {
+        $client = $this->mockClient([
+            new Response(200, [], json_encode([
+                'success' => true,
+                'result' => [
+                    'id' => 'load_balancer_id',
+                    'enabled' => false,
+                ],
+            ])),
+        ]);
+
+        $response = $client->zones()->loadBalancers()->patch('zone_id', 'load_balancer_id', [
+            'enabled' => false,
+        ]);
+
+        $this->assertTrue($response->successful());
+        $this->assertFalse($response->json('result.enabled'));
+
+        $this->assertSame('PATCH', $this->lastRequest()->getMethod());
+        $this->assertSame('/client/v4/zones/zone_id/load_balancers/load_balancer_id', $this->lastRequest()->getUri()->getPath());
+    }
 }


### PR DESCRIPTION
Adds the `Load Balancer Monitor Groups` API:
- Implements full CRUD and reference listing operations for managing groups of monitors.

Enhances existing Load Balancer resources by implementing missing operations:
- Introduces `patch`, `usage`, `search`, and `preview result` for account-level Load Balancers.
- Adds `patch` for zone-level Load Balancers.
- Implements `patch` and `references` for Load Balancer Monitors and Pools, including `patch multiple pools` for pools.
- Adds `details` for Load Balancer Regions.

Includes comprehensive documentation and unit tests for all new and enhanced API endpoints, and updates the API coverage checklist to reflect the expanded functionality.